### PR TITLE
Bump pygame version to 2.6.1

### DIFF
--- a/org.sugarlabs.CellGame.json
+++ b/org.sugarlabs.CellGame.json
@@ -21,8 +21,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://files.pythonhosted.org/packages/c6/aa/2c0c867d6cff00966cfc2152b25f61599f87e88b239e4dcb8ad5357f0f69/pygame-2.5.2.tar.gz",
-                    "sha256": "c1b89eb5d539e7ac5cf75513125fb5f2f0a2d918b1fd6e981f23bf0ac1b1c24a",
+                    "url": "https://files.pythonhosted.org/packages/49/cc/08bba60f00541f62aaa252ce0cfbd60aebd04616c0b9574f755b583e45ae/pygame-2.6.1.tar.gz",
+                    "sha256": "56fb02ead529cee00d415c3e007f75e0780c655909aaa8e8bf616ee09c9feb1f",
                     "x-checker-data": {
                         "type": "pypi",
                         "name": "pygame"


### PR DESCRIPTION
Pygame version 2.6.1 is released and is working correctly with the game.
I have tested the activity and it is working without any error.